### PR TITLE
Updating GitHub Actions Versions

### DIFF
--- a/.github/workflows/auto-create-release.yaml
+++ b/.github/workflows/auto-create-release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -56,7 +56,7 @@ jobs:
       - name: Tag Docker Image (latest)
         run: docker tag felsokning/multinet:${{ github.sha }} felsokning/multinet:latest
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: felsokning
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-build-tag-and-publish.yaml
+++ b/.github/workflows/docker-build-tag-and-publish.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@main
+      uses: actions/checkout@v7
     - name: Set up Docker
       uses: docker/setup-docker-action@v5
       with:
@@ -39,7 +39,7 @@ jobs:
     - name: Tag Docker Image (latest)
       run: docker tag felsokning/multinet:${{ github.sha }} felsokning/multinet:latest
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         username: felsokning
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/pull-request-build.yaml
+++ b/.github/workflows/pull-request-build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
     - name: Set up Docker
       uses: docker/setup-docker-action@v5
       with:


### PR DESCRIPTION
This PR updates the github actions versions to be the latest versions, as we're getting warnings about deprecated node being used for some of the github actions.